### PR TITLE
Fix to deal with broken api and numeric thread IDs

### DIFF
--- a/python/dangeru.py
+++ b/python/dangeru.py
@@ -13,7 +13,7 @@ index a board
 @returns JSON formatted into a dictionary
 '''
 def index(board, limit):
-    fetch = requests.get("https://boards.dangeru.us/api.php?type=index&board=" + board + "&ln=" + limit.__str__())
+    fetch = requests.get("https://boards.dangeru.us/api.php?type=index&board=" + board + "&ln=" + str(limit))
     fetch = fetch.text.replace('\n', ' ').replace('\r', '')
     json_f = json.loads(fetch)
     return json_f
@@ -26,10 +26,18 @@ display a thread
 @returns JSON formatted into a dictionary
 '''
 def thread(board, limit, threadid):
-    if threadid.startswith("http"):
+    # if the thread id is a string and it starts with http, just get the ID
+    if type(threadid) != type(0) and threadid.startswith("http"):
         threadid = threadid.partition("=")[2]
 
-    fetch = requests.get("https://boards.dangeru.us/api.php?type=thread&board=" + board + "&ln=" + limit.__str__() + "&thread=" + threadid.__str__())
+    fetch = requests.get("https://boards.dangeru.us/api.php?type=thread&board=" + board + "&ln=" + str(limit) + "&thread=" + str(threadid))
     fetch = fetch.text.replace('\n', ' ').replace('\r', '')
+    try:
+        idx = fetch.find("https://boards.dangeru.us/static")
+        while fetch[idx] != '}': idx += 1
+        fetch = fetch[:idx] + '"' + fetch[idx:]
+    except:
+        # dangeru/static wasn't found, he probably changed the api. Just try to decode the json without the fix
+        pass
     json_f = json.loads(fetch)
     return json_f


### PR DESCRIPTION
Currently the thread API is missing a single quote which causes the json parse to fail. This commit inserts the quote at the correct position before parsing. Also, it converts things to strings properly and lets you give the thread ID as a number (246) instead of only as a string ("246" or "https://boards.dangeru.us/tech/thread.php?=246"), all three ways work now.